### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The following example gets the `APP_ENDPOINT` meta-data value from the current p
 steps: 
   - command: ./scripts/build.sh
     plugins:
-      metadata#v0.0.1:
-        get:
-          - APP_ENDPOINT
+      - metadata#v0.0.1:
+          get:
+            - APP_ENDPOINT
 ```
 
 The following example gets `VERSION_NUMBER` from the a triggering build ,which pass through it's `BUILDKITE_JOB_ID` as `SOURCE_JOB_ID`, and sets it to `VERSION_NUMBER` on the buildkite agent environment. The job id needs to be passed in to the current pipeline. 
@@ -21,9 +21,9 @@ The following example gets `VERSION_NUMBER` from the a triggering build ,which p
 steps: 
   - command: ./scripts/build.sh
     plugins:
-      metadata#v0.0.1:
-        remoteJobid: ${SOURCE_JOB_ID}
-        getRemote:
+      - metadata#v0.0.1:
+          remoteJobid: ${SOURCE_JOB_ID}
+          getRemote:
             - VERSION_NUMBER
 ```
 
@@ -33,12 +33,12 @@ The following example gets `VERSION_NUMBER` from another pipeline, and `BUILD_ID
 steps: 
   - command: ./scripts/build.sh
     plugins:
-      metadata#v0.0.1:
-        remoteJobid: ${SOURCE_JOB_ID}
-        getRemote:
-          - VERSION_NUMBER
-        get:
-          - BUILD_ID
+      - metadata#v0.0.1:
+          remoteJobid: ${SOURCE_JOB_ID}
+          getRemote:
+            - VERSION_NUMBER
+          get:
+            - BUILD_ID
 ```
 ## Configuration
 


### PR DESCRIPTION
Hi iRExchange team! 😊

(This is the same as https://github.com/irexchange/build-info-buildkite-plugin/pull/1, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.